### PR TITLE
fix WiFiManager in autoConnect and timeClient update in timer timeout

### DIFF
--- a/firmware/GyverLamp_v1.2/time.ino
+++ b/firmware/GyverLamp_v1.2/time.ino
@@ -1,6 +1,6 @@
-void timeTick() {
-  timeClient.update();
+void timeTick() {  
   if (timeTimer.isReady()) {
+    timeClient.update();
     byte thisDay = timeClient.getDay();
     if (thisDay == 0) thisDay = 7;  // воскресенье это 0
     thisDay--;

--- a/libraries/WiFiManager/WiFiManager.cpp
+++ b/libraries/WiFiManager/WiFiManager.cpp
@@ -173,7 +173,7 @@ boolean WiFiManager::autoConnect(char const *apName, char const *apPassword) {
   // attempt to connect; should it fail, fall back to AP
   WiFi.mode(WIFI_STA);
 
-  if (connectWifi("", "") == WL_CONNECTED)   {
+  if (connectWifi(String(apName),String(apPassword)) == WL_CONNECTED)   {
     DEBUG_WM(F("IP Address:"));
     DEBUG_WM(WiFi.localIP());
     //connected


### PR DESCRIPTION
метод `autoConnect` не подключался к сети из-за того, что не получал SSID и пароль.
переместил `timeClient.update()` внутрь условия тика таймера, чтобы не мучать сервак времени на каждом цикле