### PR TITLE
load brightness from EEPROM after rebooting (загрузка яркости после чтения значения из еепром)

### DIFF
--- a/firmware/GyverLamp_v1.5.5/GyverLamp_v1.5.5.ino
+++ b/firmware/GyverLamp_v1.5.5/GyverLamp_v1.5.5.ino
@@ -163,7 +163,6 @@ void setup() {
 
   // ЛЕНТА
   FastLED.addLeds<WS2812B, LED_PIN, COLOR_ORDER>(leds, NUM_LEDS)/*.setCorrection( TypicalLEDStrip )*/;
-  FastLED.setBrightness(BRIGHTNESS);
   if (CURRENT_LIMIT > 0) FastLED.setMaxPowerInVoltsAndMilliamps(5, CURRENT_LIMIT);
   FastLED.show();
 
@@ -236,6 +235,7 @@ void setup() {
   }
   dawnMode = EEPROM.read(199);
   currentMode = (int8_t)EEPROM.read(200);
+  FastLED.setBrightness(modes[currentMode].brightness);
 
   // отправляем настройки
   sendSettings();


### PR DESCRIPTION
After rebooting, brightness was defined by constant value BRIGHTNESS. Now its value is loading from EEPROM.
После перезагрузки лампа включалась с дефолтным значением яркости BRIGHTNESS. Теперь отправка значения яркость в фастлед происходит после загрузки всех параметров из еепром.